### PR TITLE
Return readable error back to client

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -34,7 +34,7 @@ export const graphQLFetcher = (subscriptionsClient: SubscriptionClient, fallback
             variables: graphQLParams.variables,
           }, function (error, result) {
             if (error) {
-              observer.error(error);
+              observer.error(JSON.stringify(error));
             } else {
               observer.next(result);
             }


### PR DESCRIPTION
Currently if theres an error its returning [Object object] back to the client, this would return stingified error. e.g

``
[{"message":"Schema must be an instance of GraphQLSchema. Also ensure that there are not multiple versions of GraphQL installed in your node_modules directory."}]
`` 

I'm sure where else utilises this error though 👎 