### PR TITLE
Support latest websocket transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "graphql": "^0.10.5",
-    "subscriptions-transport-ws": "^0.8.1"
+    "subscriptions-transport-ws": "^0.8.2"
   },
   "scripts": {
     "compile": "tsc",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "author": "Urigo <uri.goldshtein@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "graphql": "^0.9.1",
-    "subscriptions-transport-ws": "0.5.4"
+    "graphql": "^0.10.5",
+    "subscriptions-transport-ws": "^0.8.1"
   },
   "scripts": {
     "compile": "tsc",

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -42,7 +42,7 @@ export const graphQLFetcher = (subscriptionsClient: SubscriptionClient, fallback
       return {
         subscribe: (observerOrNext: { error: Function, next: Function, complete: Function }, onError?: Function, onComplete?: Function) => {
           const observer = getObserver(observerOrNext, onError, onComplete);
-          activeSubscriptionId = (subscriptionsClient as any).executeOperation({
+          activeSubscriptionId = subscriptionsClient.executeOperation({
             query: graphQLParams.query,
             variables: graphQLParams.variables,
             operationName: graphQLParams.operationName,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -16,29 +16,52 @@ const hasSubscriptionOperation = (graphQlParams: any) => {
   return false;
 };
 
-export const graphQLFetcher = (subscriptionsClient: SubscriptionClient, fallbackFetcher: Function) => {
-  let activeSubscriptionId: number | null = null;
+function getObserver(observerOrNext: { error: Function, next: Function, complete: Function }, error?: Function, complete?: Function) {
+  if ( typeof observerOrNext === 'function' ) {
+    return {
+      next: (v: any) => observerOrNext(v),
+      error: (e: Error) => error && error(e),
+      complete: () => complete && complete(),
+    };
+  }
+
+  return observerOrNext;
+}
+
+export const graphQLFetcher = (subscriptionsClient: SubscriptionClient, fallbackFetcher?: Function) => {
+  let activeSubscriptionId: string | null = null;
 
   return (graphQLParams: any) => {
     if (subscriptionsClient && activeSubscriptionId !== null) {
       subscriptionsClient.unsubscribe(activeSubscriptionId);
+      activeSubscriptionId = null;
     }
 
-    if (subscriptionsClient && hasSubscriptionOperation(graphQLParams)) {
+    if (subscriptionsClient && (hasSubscriptionOperation(graphQLParams) ||
+        (undefined === fallbackFetcher)) ) {
       return {
-        subscribe: (observer: { error: Function, next: Function }) => {
-          observer.next('Your subscription data will appear here after server publication!');
-
+        subscribe: (observerOrNext: { error: Function, next: Function, complete: Function }, onError?: Function, onComplete?: Function) => {
+          const observer = getObserver(observerOrNext, onError, onComplete);
           activeSubscriptionId = subscriptionsClient.subscribe({
             query: graphQLParams.query,
             variables: graphQLParams.variables,
+            operationName: graphQLParams.operationName,
           }, function (error, result) {
-            if (error) {
+            if ( error === null && result === null ) {
+              observer.complete();
+            } else if (error) {
               observer.error(error);
             } else {
               observer.next(result);
             }
           });
+
+          return {
+            unsubscribe: () => {
+              subscriptionsClient.unsubscribe(activeSubscriptionId);
+              activeSubscriptionId = null;
+            },
+          };
         },
       };
     } else {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -42,15 +42,15 @@ export const graphQLFetcher = (subscriptionsClient: SubscriptionClient, fallback
       return {
         subscribe: (observerOrNext: { error: Function, next: Function, complete: Function }, onError?: Function, onComplete?: Function) => {
           const observer = getObserver(observerOrNext, onError, onComplete);
-          activeSubscriptionId = subscriptionsClient.subscribe({
+          activeSubscriptionId = (subscriptionsClient as any).executeOperation({
             query: graphQLParams.query,
             variables: graphQLParams.variables,
             operationName: graphQLParams.operationName,
-          }, function (error, result) {
+          }, function (error: Error[], result: any) {
             if ( error === null && result === null ) {
               observer.complete();
             } else if (error) {
-              observer.error(error);
+              observer.error(error[0]);
             } else {
               observer.next(result);
             }


### PR DESCRIPTION
This PR Assumes this
https://github.com/apollographql/subscriptions-transport-ws/pull/239
will be merged and realsed as version 0.8.2.

This PR adds support for latest subscription-transport client,
which also adds the option to query / mutate over websocket.
so incase fallbackFetcher is undefined, all operations should go through this interface.