### PR TITLE
"main" fix in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphiql-subscriptions-fetcher",
   "version": "0.0.2",
-  "main": "src/fetcher.js",
+  "main": "dist/fetcher.js",
   "repository": "https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher.git",
   "author": "Urigo <uri.goldshtein@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphiql-subscriptions-fetcher",
   "version": "0.0.2",
-  "main": "dist/index.js",
+  "main": "src/fetcher.js",
   "repository": "https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher.git",
   "author": "Urigo <uri.goldshtein@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
As it currently is, the package wasn't working when installed via npm or yarn, but making this fix and publishing a fork made it work for me. You could also change the name of the files that get built in the `dist` folder. 